### PR TITLE
Add missing error() method

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -250,7 +250,7 @@ function logError(message) {
 }
 
 // Ignore ENOENT to fall through as 404
-var error = function(err) {
+function error(err) {
     next('ENOENT' == err.code
         ? null
         : err);

--- a/middleware.js
+++ b/middleware.js
@@ -248,3 +248,10 @@ function log(key, val) {
 function logError(message) {
   log('error', '\x07\x1B[31m' + message + '\x1B[91m');
 }
+
+// Ignore ENOENT to fall through as 404
+var error = function(err) {
+    next('ENOENT' == err.code
+        ? null
+        : err);
+    };


### PR DESCRIPTION
it seems like the error method handling the 'ENOENT' was dropped during the refactoring
